### PR TITLE
feat(`sentry_link`): bump to sentry 8.0.0

### DIFF
--- a/sentry_link/lib/src/graph_gl_filter.dart
+++ b/sentry_link/lib/src/graph_gl_filter.dart
@@ -5,7 +5,7 @@ BeforeBreadcrumbCallback graphQlFilter([BeforeBreadcrumbCallback? filter]) {
     Breadcrumb? ogBreadcrumb,
     Hint hint,
   ) {
-    final breadCrumb = filter?.call(ogBreadcrumb, hint);
+    final breadCrumb = (filter != null) ? filter.call(ogBreadcrumb, hint) : ogBreadcrumb;
     if (breadCrumb == null) {
       return null;
     }

--- a/sentry_link/lib/src/graph_gl_filter.dart
+++ b/sentry_link/lib/src/graph_gl_filter.dart
@@ -2,10 +2,10 @@ import 'package:sentry/sentry.dart';
 
 BeforeBreadcrumbCallback graphQlFilter([BeforeBreadcrumbCallback? filter]) {
   return (
-    Breadcrumb? ogBreadcrumb, {
-    Hint? hint,
-  }) {
-    final breadCrumb = filter?.call(ogBreadcrumb, hint: hint);
+    Breadcrumb? ogBreadcrumb,
+    Hint hint,
+  ) {
+    final breadCrumb = filter?.call(ogBreadcrumb, hint);
     if (breadCrumb == null) {
       return null;
     }

--- a/sentry_link/pubspec.yaml
+++ b/sentry_link/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   gql_exec: ">=0.4.0 < 2.0.0"
   gql_link: ">=0.5.0 < 2.0.0"
   gql: ">=0.14.0 < 2.0.0"
-  sentry: ">=8.0.0 <9.0.0"
+  sentry: ^8.0.0
 
 dev_dependencies:
   lints: ^1.0.0

--- a/sentry_link/pubspec.yaml
+++ b/sentry_link/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   gql_exec: ">=0.4.0 < 2.0.0"
   gql_link: ">=0.5.0 < 2.0.0"
   gql: ">=0.14.0 < 2.0.0"
-  sentry: <9.0.0
+  sentry: ">=8.0.0 <9.0.0"
 
 dev_dependencies:
   lints: ^1.0.0

--- a/sentry_link/pubspec.yaml
+++ b/sentry_link/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   gql_exec: ">=0.4.0 < 2.0.0"
   gql_link: ">=0.5.0 < 2.0.0"
   gql: ">=0.14.0 < 2.0.0"
-  sentry: ^7.8.0
+  sentry: <9.0.0
 
 dev_dependencies:
   lints: ^1.0.0

--- a/sentry_link/test/graph_gl_filter.dart
+++ b/sentry_link/test/graph_gl_filter.dart
@@ -4,14 +4,19 @@ import 'package:test/test.dart';
 
 void main() {
   test('GraphQL urls should be filtered', () {
-    final result = graphQlFilter()(Breadcrumb.http(
-        url: Uri.parse('https://example.org/graphql'), method: 'gte'));
+    final result = graphQlFilter()(
+      Breadcrumb.http(
+          url: Uri.parse('https://example.org/graphql'), method: 'gte'),
+      Hint(),
+    );
     expect(result, null);
   });
 
   test('non GraphQL urls should not be filtered', () {
     final result = graphQlFilter()(
-        Breadcrumb.http(url: Uri.parse('https://example.org/'), method: 'gte'));
+      Breadcrumb.http(url: Uri.parse('https://example.org/'), method: 'gte'),
+      Hint(),
+    );
     expect(result, isNotNull);
   });
 }

--- a/sentry_link/test/graph_gl_filter.dart
+++ b/sentry_link/test/graph_gl_filter.dart
@@ -6,7 +6,7 @@ void main() {
   test('GraphQL urls should be filtered', () {
     final result = graphQlFilter()(
       Breadcrumb.http(
-          url: Uri.parse('https://example.org/graphql'), method: 'gte'),
+          url: Uri.parse('https://example.org/graphql'), method: 'get'),
       Hint(),
     );
     expect(result, null);
@@ -14,7 +14,7 @@ void main() {
 
   test('non GraphQL urls should not be filtered', () {
     final result = graphQlFilter()(
-      Breadcrumb.http(url: Uri.parse('https://example.org/'), method: 'gte'),
+      Breadcrumb.http(url: Uri.parse('https://example.org/'), method: 'get'),
       Hint(),
     );
     expect(result, isNotNull);


### PR DESCRIPTION
Fixes #12 

Signature of `graphQlFilter()` optional `filter` parameter as changed with `sentry` >=8.0.0 (`BeforeBreadcrumbCallback`), which imply a breaking change for the new version